### PR TITLE
Fix path handling in TTS engine

### DIFF
--- a/app/tts_engine.py
+++ b/app/tts_engine.py
@@ -7,7 +7,8 @@ import numpy as np
 from pathlib import Path
 import soundfile as sf
 
-REFERENCE_AUDIO = "C:/Users/dima-/ML/tts_microservice/static/speakers/speaker_Andrew.wav"
+BASE_DIR = Path(__file__).resolve().parent.parent
+REFERENCE_AUDIO = BASE_DIR / "static" / "speakers" / "speaker_Andrew.wav"
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 tts = TTS("tts_models/multilingual/multi-dataset/xtts_v2", progress_bar=False).to(device)
@@ -23,7 +24,8 @@ def synthesize_text(text, output_path, file_id=None):
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     # Прогресс сохраняется в файл с file_id
-    progress_path = Path(f"app/progress_{file_id}.json") if file_id else Path("app/progress.json")
+    progress_dir = Path(__file__).resolve().parent
+    progress_path = progress_dir / (f"progress_{file_id}.json" if file_id else "progress.json")
     with open(progress_path, "w", encoding="utf-8") as f:
         json.dump({"progress": 0}, f)
 
@@ -31,7 +33,7 @@ def synthesize_text(text, output_path, file_id=None):
     for i, fragment in enumerate(fragments):
         audio = tts.tts(
             text=fragment,
-            speaker_wav=REFERENCE_AUDIO,
+            speaker_wav=str(REFERENCE_AUDIO),
             language="ru",
             split_sentences=False,
             file_path=None,


### PR DESCRIPTION
## Summary
- dynamically build the path to the reference speaker wav
- write progress files relative to module directory
- send a string path to the underlying TTS engine

## Testing
- `python3 -m py_compile app/tts_engine.py app/main.py`
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685fe3e89c98832facd4d7817f14b276